### PR TITLE
Replace RollupConfig usages with LevelRollupConfig

### DIFF
--- a/src/api/async_api.rs
+++ b/src/api/async_api.rs
@@ -108,7 +108,7 @@ mod tests {
     use super::*;
     use crate::config::Config; // Ensure Config is imported for get_rollup_test_config
     use crate::test_utils::get_test_config; // Use the shared test config
-    use crate::types::time::RollupConfig;
+    use crate::types::time::LevelRollupConfig;
     use crate::StorageType;
     use crate::TimeLevel;
     use std::sync::OnceLock;
@@ -129,20 +129,20 @@ mod tests {
                 TimeLevel { // L0
                     name: "L0_rollup_test".to_string(),
                     duration_seconds: 60,
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: 2, 
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 2,
                         max_page_age_seconds: 300,
-                        force_rollup_on_shutdown: false
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: None,
                 },
                 TimeLevel { // L1
                     name: "L1_rollup_test".to_string(),
                     duration_seconds: 300,
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: 10, 
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 10,
                         max_page_age_seconds: 86400,
-                        force_rollup_on_shutdown: false
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: None,
                 }

--- a/src/config/tests/validation_tests.rs
+++ b/src/config/tests/validation_tests.rs
@@ -1,6 +1,6 @@
 use crate::config::{
     CompressionAlgorithm, CompressionConfig, Config, LogLevel, LoggingConfig, RetentionConfig,
-    RollupConfig, StorageConfig, StorageType, TimeHierarchyConfig,
+    LevelRollupConfig, StorageConfig, StorageType, TimeHierarchyConfig,
 };
 use crate::error::CJError;
 use crate::config::validation::validate_config;
@@ -8,7 +8,6 @@ use crate::config::validation::validate_config;
 fn create_test_config() -> Config {
     Config {
         time_hierarchy: TimeHierarchyConfig::default(),
-        rollup: RollupConfig::default(),
         storage: StorageConfig {
             storage_type: StorageType::File,
             base_path: "./data".to_string(),
@@ -31,6 +30,7 @@ fn create_test_config() -> Config {
             period_seconds: 30 * 24 * 60 * 60, // 30 days
             cleanup_interval_seconds: 3600, // 1 hour
         },
+        force_rollup_on_shutdown: true,
     }
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -450,14 +450,14 @@ mod tests {
     use crate::config::{
         CompressionConfig, RetentionConfig, StorageConfig,
     };
-    use crate::types::{CompressionAlgorithm, TimeLevel}; // Import the TimeLevel STRUCT and CompressionAlgorithm
+    use crate::types::{CompressionAlgorithm, TimeLevel, LevelRollupConfig}; // Import the TimeLevel STRUCT and CompressionAlgorithm
 
     #[test]
     fn test_validate_time_hierarchy() {
         // Valid hierarchy
         let valid = TimeHierarchyConfig {
             levels: vec![TimeLevel {
-                    rollup_config: RollupConfig::default(),
+                    rollup_config: LevelRollupConfig::default(),
                     retention_policy: None,
                 name: "test".to_string(),
                 duration_seconds: 60,
@@ -473,13 +473,13 @@ mod tests {
         let duplicate = TimeHierarchyConfig {
             levels: vec![
                 TimeLevel {
-                    rollup_config: RollupConfig::default(),
+                    rollup_config: LevelRollupConfig::default(),
                     retention_policy: None,
                     name: "test".to_string(),
                     duration_seconds: 60,
                 },
                 TimeLevel {
-                    rollup_config: RollupConfig::default(),
+                    rollup_config: LevelRollupConfig::default(),
                     retention_policy: None,
                     name: "test".to_string(),
                     duration_seconds: 3600,
@@ -492,13 +492,13 @@ mod tests {
         let bad_order = TimeHierarchyConfig {
             levels: vec![
                 TimeLevel {
-                    rollup_config: RollupConfig::default(),
+                    rollup_config: LevelRollupConfig::default(),
                     retention_policy: None,
                     name: "hour".to_string(),
                     duration_seconds: 3600,
                 },
                 TimeLevel {
-                    rollup_config: RollupConfig::default(),
+                    rollup_config: LevelRollupConfig::default(),
                     retention_policy: None,
                     name: "minute".to_string(),
                     duration_seconds: 60,

--- a/src/core/page.rs
+++ b/src/core/page.rs
@@ -325,7 +325,7 @@ mod tests {
 
     // Removed local PAGE_TEST_MUTEX, lazy_static, and unused Mutex/Ordering imports
 
-    use crate::types::time::{TimeHierarchyConfig, TimeLevel as TypeTimeLevel, RollupConfig}; // Renamed to avoid conflict
+    use crate::types::time::{TimeHierarchyConfig, TimeLevel as TypeTimeLevel, LevelRollupConfig}; // Renamed to avoid conflict
     use crate::core::{SHARED_TEST_ID_MUTEX, reset_global_ids}; // Import shared test items
 
     use crate::config::{Config, StorageConfig, CompressionConfig, LoggingConfig, MetricsConfig, RetentionConfig};
@@ -336,19 +336,19 @@ mod tests {
             time_hierarchy: TimeHierarchyConfig {
                 levels: vec![
                     TypeTimeLevel {
-                            rollup_config: RollupConfig::default(),
+                            rollup_config: LevelRollupConfig::default(),
                             retention_policy: None, name: "second".to_string(), duration_seconds: 1 },
                     TypeTimeLevel {
-                            rollup_config: RollupConfig::default(),
+                            rollup_config: LevelRollupConfig::default(),
                             retention_policy: None, name: "minute".to_string(), duration_seconds: 60 },
                 ]
             },
-            rollup: Default::default(),
             storage: StorageConfig { storage_type: StorageType::Memory, base_path: "./cjtmp_page_test".to_string(), max_open_files: 100 },
             compression: CompressionConfig::default(),
             logging: LoggingConfig::default(),
             metrics: MetricsConfig::default(),
             retention: RetentionConfig::default(),
+            force_rollup_on_shutdown: false,
         }
     }
 

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -1188,7 +1188,7 @@ mod tests_to_merge {
     use crate::core::{SHARED_TEST_ID_MUTEX, reset_global_ids}; // Import shared test utilities
     
     use crate::config::{Config, StorageConfig, CompressionConfig, LoggingConfig, MetricsConfig, RetentionConfig};
-    use crate::types::time::{RollupConfig, TimeLevel};
+    use crate::types::time::{LevelRollupConfig, TimeLevel};
     use crate::{StorageType, TimeHierarchyConfig, CompressionAlgorithm};
     use std::fs::File as StdFile; // For opening the backup zip file
 
@@ -1197,20 +1197,20 @@ mod tests_to_merge {
             time_hierarchy: TimeHierarchyConfig {
                 levels: vec![
                     TimeLevel {
-                            rollup_config: RollupConfig::default(),
+                            rollup_config: LevelRollupConfig::default(),
                             retention_policy: None, name: "second".to_string(), duration_seconds: 1 },
                     TimeLevel {
-                            rollup_config: RollupConfig::default(),
+                            rollup_config: LevelRollupConfig::default(),
                             retention_policy: None, name: "minute".to_string(), duration_seconds: 60 },
                 ]
             },
-            rollup: Default::default(),
             // For file storage tests, we might still use Memory for config simplicity unless test needs file specifics
-            storage: StorageConfig { storage_type: StorageType::Memory, base_path: "./cjtmp_file_test".to_string(), max_open_files: 100 }, 
+            storage: StorageConfig { storage_type: StorageType::Memory, base_path: "./cjtmp_file_test".to_string(), max_open_files: 100 },
             compression: CompressionConfig::default(),
             logging: LoggingConfig::default(),
             metrics: MetricsConfig::default(),
             retention: RetentionConfig::default(),
+            force_rollup_on_shutdown: false,
         }
     }
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -187,7 +187,7 @@ mod tests {
     use crate::core::{SHARED_TEST_ID_MUTEX, reset_global_ids}; // Import shared test utilities
     use crate::config::{Config, StorageConfig, CompressionConfig, LoggingConfig, MetricsConfig, RetentionConfig};
     use crate::{core::leaf::JournalLeaf, StorageType, core::page::PageContent};
-    use crate::types::time::{TimeHierarchyConfig, TimeLevel as TypeTimeLevel, RollupConfig};
+    use crate::types::time::{TimeHierarchyConfig, TimeLevel as TypeTimeLevel, LevelRollupConfig};
     use crate::core::leaf::{LeafData, LeafDataV1}; // Added missing imports
 
     fn get_test_config() -> Config {
@@ -195,19 +195,19 @@ mod tests {
             time_hierarchy: TimeHierarchyConfig {
                 levels: vec![
                     TypeTimeLevel {
-                            rollup_config: RollupConfig::default(),
+                            rollup_config: LevelRollupConfig::default(),
                             retention_policy: None, name: "second".to_string(), duration_seconds: 1 },
                     TypeTimeLevel {
-                            rollup_config: RollupConfig::default(),
+                            rollup_config: LevelRollupConfig::default(),
                             retention_policy: None, name: "minute".to_string(), duration_seconds: 60 },
                 ]
             },
-            rollup: Default::default(),
             storage: StorageConfig { storage_type: StorageType::Memory, base_path: "./cjtmp_mem_test".to_string(), max_open_files: 100 },
             compression: CompressionConfig::default(),
             logging: LoggingConfig::default(),
             metrics: MetricsConfig::default(),
             retention: RetentionConfig::default(),
+            force_rollup_on_shutdown: false,
         }
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -3,7 +3,7 @@
 #![cfg(test)] // Ensure this module is only compiled for tests
 
 use crate::config::Config;
-use crate::{RollupConfig, StorageType, TimeLevel};
+use crate::{LevelRollupConfig, StorageType, TimeLevel};
 use std::sync::OnceLock;
 
 /// Provides a common test configuration.
@@ -17,13 +17,14 @@ pub fn get_test_config() -> &'static Config {
         config.time_hierarchy.levels = vec![TimeLevel {
             name: "L0_test_default".to_string(), // Generic name for test config
             duration_seconds: 60,
-            rollup_config: RollupConfig {
-                max_leaves_per_page: 10,
+            rollup_config: LevelRollupConfig {
+                max_items_per_page: 10,
                 max_page_age_seconds: 300,
-                force_rollup_on_shutdown: false,
+                ..LevelRollupConfig::default()
             },
             retention_policy: None,
         }];
+        config.force_rollup_on_shutdown = false;
         config
     })
 }

--- a/tests/time_manager_tests.rs.bak
+++ b/tests/time_manager_tests.rs.bak
@@ -4,8 +4,8 @@ use civicjournal_time::core::page::{JournalPage, PageContent, NEXT_PAGE_ID};
 use civicjournal_time::core::{SHARED_TEST_ID_MUTEX, reset_global_ids};
 use civicjournal_time::storage::memory::MemoryStorage;
 use civicjournal_time::config::{
-    Config, RetentionConfig, StorageConfig as TestStorageConfig, CompressionConfig, 
-    LoggingConfig, MetricsConfig, TimeHierarchyConfig, TimeLevel, RollupConfig, RollupRetentionPolicy
+    Config, RetentionConfig, StorageConfig as TestStorageConfig, CompressionConfig,
+    LoggingConfig, MetricsConfig, TimeHierarchyConfig, TimeLevel, LevelRollupConfig, RollupRetentionPolicy
 };
 use civicjournal_time::StorageType as TestStorageType;
 use civicjournal_time::CompressionAlgorithm;
@@ -29,20 +29,20 @@ fn create_test_config(
         time_hierarchy: TimeHierarchyConfig {
             levels: vec![
                 TimeLevel {
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: 1,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 1,
                         max_page_age_seconds: 1000, // Match global test default
-                        force_rollup_on_shutdown: false,
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: l0_policy,
                     name: "seconds".to_string(),
                     duration_seconds: 1
                 },
                 TimeLevel {
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: 1,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 1,
                         max_page_age_seconds: 1000, // Match global test default
-                        force_rollup_on_shutdown: false,
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: l1_policy,
                     name: "minutes".to_string(),
@@ -50,11 +50,7 @@ fn create_test_config(
                 },
             ],
         },
-        rollup: RollupConfig { // Sensible defaults for most tests
-            max_leaves_per_page: 1, // Corrected back to 1 for test consistency
-            max_page_age_seconds: 1000,
-            force_rollup_on_shutdown: false,
-        },
+        force_rollup_on_shutdown: false,
         storage: Default::default(), // Assuming TestStorageConfig will be used or it's okay
         retention: RetentionConfig {
             enabled: retention_enabled,
@@ -365,33 +361,29 @@ fn create_cascading_test_config_and_manager() -> (TimeHierarchyManager, Arc<Memo
         time_hierarchy: TimeHierarchyConfig {
             levels: vec![
                 TimeLevel {
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: 1,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 1,
                         max_page_age_seconds: 1000,
-                        force_rollup_on_shutdown: false,
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: None, name: "L0".to_string(), duration_seconds: 1 },
                 TimeLevel {
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: 1,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 1,
                         max_page_age_seconds: 1000,
-                        force_rollup_on_shutdown: false,
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: None, name: "L1".to_string(), duration_seconds: 1 },
                 TimeLevel {
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: 1,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 1,
                         max_page_age_seconds: 1000,
-                        force_rollup_on_shutdown: false,
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: None, name: "L2".to_string(), duration_seconds: 1 },
             ],
         },
-        rollup: RollupConfig {
-            max_leaves_per_page: 1, // This is key for cascading by item count
-            max_page_age_seconds: 1000, // Large age so it doesn't interfere with item count based finalization
-            force_rollup_on_shutdown: false,
-        },
+        force_rollup_on_shutdown: false,
         storage: Default::default(),
         retention: RetentionConfig { // Default retention disabled for these rollup tests
             enabled: false,
@@ -794,31 +786,27 @@ fn create_age_based_rollup_config_and_manager(
             levels: vec![
                 TimeLevel { // Level 0
                     name: "L0_age_test".to_string(),
-                    duration_seconds: 60, 
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: l0_max_leaves as usize,
+                    duration_seconds: 60,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: l0_max_leaves as usize,
                         max_page_age_seconds: l0_max_age_secs,
-                        force_rollup_on_shutdown: false,
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: None,
                 },
                 TimeLevel { // Level 1
                     name: "L1_age_test".to_string(),
-                    duration_seconds: 3600, 
-                    rollup_config: RollupConfig {
-                        max_leaves_per_page: l1_max_leaves as usize,
+                    duration_seconds: 3600,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: l1_max_leaves as usize,
                         max_page_age_seconds: l1_max_age_secs,
-                        force_rollup_on_shutdown: false,
+                        ..LevelRollupConfig::default()
                     },
                     retention_policy: None,
                 },
             ],
         },
-        rollup: RollupConfig { 
-            max_leaves_per_page: 1000, 
-            max_page_age_seconds: 3600 * 24, 
-            force_rollup_on_shutdown: false,
-        },
+        force_rollup_on_shutdown: false,
         storage: TestStorageConfig {
             storage_type: TestStorageType::Memory,
             base_path: "".to_string(),
@@ -838,17 +826,3 @@ fn create_age_based_rollup_config_and_manager(
     let manager = TimeHierarchyManager::new(config.clone(), storage.clone());
     (manager, storage)
 }
-
-#[tokio::test]
-async fn test_age_based_rollup_cascade() {
-    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
-    reset_global_ids();
-
-    let l0_max_age = 2; 
-    let l1_max_age = 4; 
-    let (manager, storage) = create_age_based_rollup_config_and_manager(l0_max_age, 100, l1_max_age, 100);
-
-    let initial_time = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(); 
-
-    let leaf1_ts = initial_time;
-    let leaf1 = JournalLeaf::new(leaf1_ts, None


### PR DESCRIPTION
## Summary
- replace deprecated `RollupConfig` with `LevelRollupConfig`
- adjust config initializations and tests
- drop broken time_manager_tests integration test

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_684060ead9f8832c851efcf650c3a636