### PR TITLE
Expand Turnstile module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ url = "2.5.0"  # For URL parsing in metrics endpoint validation
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 toml = { version = "0.7", features = ["preserve_order"] }
+libc = "0.2"
 
 # Time handling
 chrono = { version = "0.4", features = ["serde", "clock", "std"] }

--- a/src/ffi/c_ffi.rs
+++ b/src/ffi/c_ffi.rs
@@ -55,6 +55,202 @@ pub extern "C" fn civicjournal_free_string(s: *mut c_char) {
 }
 */
 
+use crate::turnstile::Turnstile;
+use serde::Deserialize;
+use std::path::PathBuf;
+use libc::{c_char, c_int};
+use std::ffi::{CStr, CString};
+
+/// Opaque CJT client handle used across FFI calls.
+#[repr(C)]
+pub struct CJTClient {
+    ts: Turnstile,
+}
+
+#[derive(Deserialize)]
+struct InitConfig {
+    storage_path: Option<String>,
+    max_retries: Option<u32>,
+    orphan_event_logging: Option<bool>,
+}
+
+/// Initialize a CJT client from JSON config.
+#[no_mangle]
+pub extern "C" fn cjt_init(config_json: *const c_char) -> *mut CJTClient {
+    if config_json.is_null() {
+        return std::ptr::null_mut();
+    }
+    let c_str = unsafe { CStr::from_ptr(config_json) };
+    let config_str = match c_str.to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let cfg: InitConfig = serde_json::from_str(config_str).unwrap_or(InitConfig {
+        storage_path: None,
+        max_retries: None,
+        orphan_event_logging: None,
+    });
+    let ts = Turnstile::new_with_storage(
+        "00".repeat(32),
+        cfg.max_retries.unwrap_or(5),
+        cfg.storage_path.map(PathBuf::from),
+        cfg.orphan_event_logging.unwrap_or(true),
+    );
+    Box::into_raw(Box::new(CJTClient { ts }))
+}
+
+/// Destroy a CJT client.
+#[no_mangle]
+pub extern "C" fn cjt_destroy(ptr: *mut CJTClient) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe { drop(Box::from_raw(ptr)); }
+}
+
+/// Append a payload and get back the ticket hash.
+#[no_mangle]
+pub extern "C" fn cjt_turnstile_append(
+    ptr: *mut CJTClient,
+    payload_json: *const c_char,
+    timestamp: u64,
+    out_ticket: *mut c_char,
+) -> c_int {
+    if ptr.is_null() || payload_json.is_null() || out_ticket.is_null() {
+        return -1;
+    }
+    let ts = unsafe { &mut (*ptr).ts };
+    let c_str = unsafe { CStr::from_ptr(payload_json) };
+    match c_str.to_str() {
+        Ok(payload) => match ts.append(payload, timestamp) {
+            Ok(ticket) => {
+                let bytes = ticket.as_bytes();
+                unsafe {
+                    std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_ticket as *mut u8, bytes.len());
+                    *out_ticket.add(64) = 0;
+                }
+                0
+            }
+            Err(_) => -2,
+        },
+        Err(_) => -3,
+    }
+}
+
+/// Confirm or reject a pending ticket.
+#[no_mangle]
+pub extern "C" fn cjt_confirm_ticket(
+    ptr: *mut CJTClient,
+    leaf_hash: *const c_char,
+    status: c_int,
+    err_msg: *const c_char,
+) -> c_int {
+    if ptr.is_null() || leaf_hash.is_null() {
+        return -1;
+    }
+    let ts = unsafe { &mut (*ptr).ts };
+    let hash = unsafe { CStr::from_ptr(leaf_hash) }.to_string_lossy();
+    let err = if !err_msg.is_null() {
+        Some(unsafe { CStr::from_ptr(err_msg) }.to_string_lossy().to_string())
+    } else {
+        None
+    };
+    match ts.confirm_ticket(&hash, status != 0, err.as_deref()) {
+        Ok(_) => 0,
+        Err(_) => -2,
+    }
+}
+
+/// Retry the next pending ticket using the provided callback.
+#[no_mangle]
+pub extern "C" fn cjt_retry_next_pending(
+    ptr: *mut CJTClient,
+    callback: Option<extern "C" fn(*const c_char, *const c_char, *const c_char) -> c_int>,
+) -> c_int {
+    if ptr.is_null() {
+        return -1;
+    }
+    let ts = unsafe { &mut (*ptr).ts };
+    let cb = match callback {
+        Some(func) => func,
+        None => return -1,
+    };
+    let rc = ts
+        .retry_next_pending(|prev, payload, leaf| {
+            let prev_c = CString::new(prev).unwrap();
+            let payload_c = CString::new(payload).unwrap();
+            let leaf_c = CString::new(leaf).unwrap();
+            cb(prev_c.as_ptr(), payload_c.as_ptr(), leaf_c.as_ptr()) as i32
+        })
+        .unwrap_or(-3);
+    rc
+}
+
+/// Check if a leaf exists.
+#[no_mangle]
+pub extern "C" fn cjt_leaf_exists(ptr: *mut CJTClient, leaf_hash: *const c_char) -> c_int {
+    if ptr.is_null() || leaf_hash.is_null() {
+        return -1;
+    }
+    let ts = unsafe { &mut (*ptr).ts };
+    let hash = unsafe { CStr::from_ptr(leaf_hash) }.to_string_lossy();
+    match ts.leaf_exists(&hash) {
+        Ok(true) => 1,
+        Ok(false) => 0,
+        Err(_) => -2,
+    }
+}
+
+/// Get latest committed leaf hash.
+#[no_mangle]
+pub extern "C" fn cjt_get_latest_leaf_hash(ptr: *mut CJTClient, out_hash: *mut c_char) -> c_int {
+    if ptr.is_null() || out_hash.is_null() {
+        return -1;
+    }
+    let ts = unsafe { &mut (*ptr).ts };
+    let hash = ts.latest_leaf_hash();
+    let bytes = hash.as_bytes();
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_hash as *mut u8, bytes.len());
+        *out_hash.add(64) = 0;
+    }
+    0
+}
+
+/// Get pending count.
+#[no_mangle]
+pub extern "C" fn cjt_pending_count(ptr: *mut CJTClient) -> c_int {
+    if ptr.is_null() {
+        return -1;
+    }
+    let ts = unsafe { &mut (*ptr).ts };
+    ts.pending_count() as c_int
+}
+
+/// List pending hashes.
+#[no_mangle]
+pub extern "C" fn cjt_list_pending(
+    ptr: *mut CJTClient,
+    out_hashes: *mut [c_char; 65],
+    max_entries: c_int,
+) -> c_int {
+    if ptr.is_null() || out_hashes.is_null() {
+        return -1;
+    }
+    let ts = unsafe { &mut (*ptr).ts };
+    let max = max_entries as usize;
+    let hashes = ts.list_pending(max);
+    let slice = unsafe { std::slice::from_raw_parts_mut(out_hashes, max) };
+    for (i, h) in hashes.iter().enumerate() {
+        let bytes = h.as_bytes();
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), slice[i].as_mut_ptr() as *mut u8, bytes.len());
+            slice[i][64] = 0;
+        }
+    }
+    hashes.len() as c_int
+}
+
 #[cfg(test)]
 mod tests {
     

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ pub mod core;
 pub mod error;
 /// Foreign Function Interface (FFI) for exposing CivicJournal functionality to other languages.
 pub mod ffi;
+/// Turnstile workflow implementation
+pub mod turnstile;
 /// Storage backends for persisting journal data.
 pub mod storage;
 /// Time-related utilities, including hierarchy levels and time units.

--- a/src/turnstile/mod.rs
+++ b/src/turnstile/mod.rs
@@ -1,0 +1,316 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use crate::core::hash::sha256_hash_concat;
+use crate::error::{CJError, Result as CJResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Status of a pending ticket.
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PendingStatus {
+    /// Still waiting for confirmation from the database
+    Pending,
+    /// Ticket confirmed and chain advanced
+    Committed,
+    /// Ticket failed permanently after exceeding retries or corruption
+    FailedPermanent,
+}
+
+/// A pending turnstile entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingEntry {
+    /// Previous committed leaf hash (hex)
+    pub prev_hash: String,
+    /// Original payload JSON
+    pub payload_json: String,
+    /// Unix timestamp for the payload
+    pub timestamp: u64,
+    /// Number of retry attempts
+    pub retry_count: u32,
+    /// Last error message if a retry failed
+    pub last_error: Option<String>,
+    /// Current status
+    pub status: PendingStatus,
+}
+
+/// An orphan event logged when a database insert fails.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrphanEvent {
+    /// Hash of the orphan leaf itself
+    pub leaf_hash: String,
+    /// Hash of the payload that failed
+    pub orig_hash: String,
+    /// Error message from the database
+    pub error_msg: String,
+    /// Timestamp of the original payload
+    pub timestamp: u64,
+}
+
+impl PendingEntry {
+    fn new(prev_hash: String, payload_json: String, timestamp: u64) -> Self {
+        PendingEntry {
+            prev_hash,
+            payload_json,
+            timestamp,
+            retry_count: 0,
+            last_error: None,
+            status: PendingStatus::Pending,
+        }
+    }
+}
+
+/// Turnstile manager handling pending tickets and persistence.
+#[derive(Debug)]
+pub struct Turnstile {
+    prev_leaf_hash: String,
+    pending: HashMap<String, PendingEntry>,
+    committed: HashSet<String>,
+    orphans: Vec<OrphanEvent>,
+    max_retries: u32,
+    storage_path: Option<PathBuf>,
+    log_orphans: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedState {
+    prev_leaf_hash: String,
+    pending: HashMap<String, PendingEntry>,
+    committed: HashSet<String>,
+    orphans: Vec<OrphanEvent>,
+}
+
+impl Turnstile {
+    /// Create a new turnstile instance with the given starting hash and max retries.
+    pub fn new(initial_prev_hash: String, max_retries: u32) -> Self {
+        Self::new_with_storage(initial_prev_hash, max_retries, None, true)
+    }
+
+    /// Create a new turnstile instance with optional persistence path and
+    /// orphan logging toggle.
+    pub fn new_with_storage(
+        initial_prev_hash: String,
+        max_retries: u32,
+        storage_path: Option<PathBuf>,
+        log_orphans: bool,
+    ) -> Self {
+        let mut ts = Turnstile {
+            prev_leaf_hash: initial_prev_hash,
+            pending: HashMap::new(),
+            committed: HashSet::new(),
+            orphans: Vec::new(),
+            max_retries,
+            storage_path,
+            log_orphans,
+        };
+        let _ = ts.load_state();
+        ts
+    }
+
+    fn compute_hash(prev_hash_hex: &str, payload_json: &str) -> CJResult<String> {
+        // Validate JSON
+        serde_json::from_str::<Value>(payload_json)?;
+        let prev_raw = hex::decode(prev_hash_hex).map_err(|e| CJError::new(e.to_string()))?;
+        let digest = sha256_hash_concat(&[&prev_raw, payload_json.as_bytes()]);
+        Ok(hex::encode(digest))
+    }
+
+    fn state_file(path: &Path) -> PathBuf {
+        path.join("turnstile_state.json")
+    }
+
+    fn load_state(&mut self) -> CJResult<()> {
+        let Some(path) = &self.storage_path else { return Ok(()); };
+        let file = Self::state_file(path);
+        if !file.exists() {
+            return Ok(());
+        }
+        let data = fs::read(&file)?;
+        let state: PersistedState = serde_json::from_slice(&data)?;
+        self.prev_leaf_hash = state.prev_leaf_hash;
+        self.pending = state.pending;
+        self.committed = state.committed;
+        self.orphans = state.orphans;
+        Ok(())
+    }
+
+    fn persist_state(&self) -> CJResult<()> {
+        let Some(path) = &self.storage_path else { return Ok(()); };
+        fs::create_dir_all(path)?;
+        let state = PersistedState {
+            prev_leaf_hash: self.prev_leaf_hash.clone(),
+            pending: self.pending.clone(),
+            committed: self.committed.clone(),
+            orphans: self.orphans.clone(),
+        };
+        let data = serde_json::to_vec(&state)?;
+        fs::write(Self::state_file(path), data)?;
+        Ok(())
+    }
+
+    fn log_orphan_leaf(&mut self, orig_hash: &str, msg: &str, timestamp: u64) -> CJResult<()> {
+        if !self.log_orphans {
+            return Ok(());
+        }
+        let json = serde_json::json!({
+            "type": "orphan",
+            "orig_hash": orig_hash,
+            "error_msg": msg,
+            "timestamp": timestamp,
+        });
+        let json_str = json.to_string();
+        let orphan_hash = Self::compute_hash(&self.prev_leaf_hash, &json_str)?;
+        self.prev_leaf_hash = orphan_hash.clone();
+        self.committed.insert(orphan_hash.clone());
+        self.orphans.push(OrphanEvent {
+            leaf_hash: orphan_hash,
+            orig_hash: orig_hash.to_string(),
+            error_msg: msg.to_string(),
+            timestamp,
+        });
+        Ok(())
+    }
+
+    /// Append a payload to the pending list and return the ticket hash.
+    pub fn append(&mut self, payload_json: &str, timestamp: u64) -> CJResult<String> {
+        let ticket = Self::compute_hash(&self.prev_leaf_hash, payload_json)?;
+        let entry = PendingEntry::new(self.prev_leaf_hash.clone(), payload_json.to_string(), timestamp);
+        self.pending.insert(ticket.clone(), entry);
+        self.persist_state()?;
+        Ok(ticket)
+    }
+
+    /// Confirm or reject a ticket.
+    pub fn confirm_ticket(&mut self, leaf_hash: &str, status: bool, error_msg: Option<&str>) -> CJResult<()> {
+        let timestamp;
+        {
+            let entry = self.pending.get_mut(leaf_hash).ok_or_else(|| CJError::not_found("ticket"))?;
+            if status {
+                entry.status = PendingStatus::Committed;
+                self.prev_leaf_hash = leaf_hash.to_string();
+                self.committed.insert(leaf_hash.to_string());
+                return self.persist_state();
+            } else if let Some(msg) = error_msg {
+                entry.last_error = Some(msg.to_string());
+                timestamp = entry.timestamp;
+            } else {
+                return self.persist_state();
+            }
+        }
+        if let Some(msg) = error_msg {
+            self.log_orphan_leaf(leaf_hash, msg, timestamp)?;
+        }
+        self.persist_state()
+    }
+
+    /// Retry the oldest pending entry using the provided callback.
+    pub fn retry_next_pending<F>(&mut self, mut callback: F) -> CJResult<i32>
+    where
+        F: FnMut(&str, &str, &str) -> i32,
+    {
+        let leaf_hash = match self
+            .pending
+            .iter()
+            .filter(|(_, e)| e.status == PendingStatus::Pending)
+            .min_by_key(|(_, e)| e.timestamp)
+            .map(|(h, _)| h.clone())
+        {
+            Some(h) => h,
+            None => return Ok(-1),
+        };
+
+        let timestamp;
+        {
+            let entry = self.pending.get_mut(&leaf_hash).expect("exists");
+            let computed = Self::compute_hash(&entry.prev_hash, &entry.payload_json)?;
+            if computed != leaf_hash {
+                entry.status = PendingStatus::FailedPermanent;
+                return Ok(-2);
+            }
+            timestamp = entry.timestamp;
+            let prev_hash = entry.prev_hash.clone();
+            let payload_json = entry.payload_json.clone();
+            let rc = callback(&prev_hash, &payload_json, &leaf_hash);
+            if rc == 1 {
+                entry.status = PendingStatus::Committed;
+                self.prev_leaf_hash = leaf_hash.clone();
+                self.committed.insert(leaf_hash);
+                self.persist_state()?;
+                return Ok(0);
+            } else {
+                entry.retry_count += 1;
+                if entry.retry_count >= self.max_retries {
+                    entry.status = PendingStatus::FailedPermanent;
+                    // drop entry before logging
+                } else {
+                    entry.last_error = Some("retry failed".to_string());
+                    // drop entry before logging
+                }
+            }
+        }
+        let mut entry = self.pending.get_mut(&leaf_hash).expect("exists");
+        if entry.retry_count >= self.max_retries {
+            self.log_orphan_leaf(&leaf_hash, "retry failed", timestamp)?;
+            self.persist_state()?;
+            Ok(2)
+        } else {
+            self.log_orphan_leaf(&leaf_hash, "retry failed", timestamp)?;
+            self.persist_state()?;
+            Ok(1)
+        }
+    }
+
+    /// Check if a leaf exists in pending or committed lists.
+    pub fn leaf_exists(&self, leaf_hash: &str) -> CJResult<bool> {
+        if self.pending.contains_key(leaf_hash) || self.committed.contains(leaf_hash) {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Get the latest committed leaf hash.
+    pub fn latest_leaf_hash(&self) -> String {
+        self.prev_leaf_hash.clone()
+    }
+
+    /// Number of pending entries.
+    pub fn pending_count(&self) -> usize {
+        self.pending.values().filter(|e| e.status == PendingStatus::Pending).count()
+    }
+
+    /// List up to max_entries pending hashes.
+    pub fn list_pending(&self, max_entries: usize) -> Vec<String> {
+        self.pending
+            .iter()
+            .filter(|(_, e)| e.status == PendingStatus::Pending)
+            .take(max_entries)
+            .map(|(h, _)| h.clone())
+            .collect()
+    }
+
+    /// Access logged orphan events.
+    pub fn orphan_events(&self) -> &[OrphanEvent] {
+        &self.orphans
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_append_and_confirm() {
+        let mut ts = Turnstile::new("00".repeat(32), 3);
+        let ticket = ts.append("{\"foo\":\"bar\"}", 0).unwrap();
+        assert_eq!(
+            ticket,
+            "671fde0a1b5143bb2f28c9f08f5db13fed479b6313f56f8145260615d8cb05b4"
+        );
+        assert_eq!(ts.pending_count(), 1);
+        ts.confirm_ticket(&ticket, true, None).unwrap();
+        assert_eq!(ts.pending_count(), 0);
+        assert_eq!(ts.latest_leaf_hash(), ticket);
+    }
+}

--- a/tests/turnstile_ffi_tests.rs
+++ b/tests/turnstile_ffi_tests.rs
@@ -1,0 +1,74 @@
+use civicjournal_time::ffi::c_ffi::*;
+use std::ffi::{CString, CStr};
+use libc::{c_char, c_int};
+
+#[test]
+fn test_ffi_append_confirm_get_latest() {
+    let cfg = CString::new("{}").unwrap();
+    let client = unsafe { cjt_init(cfg.as_ptr()) };
+    assert!(!client.is_null());
+
+    let payload = CString::new("{\"foo\":\"bar\"}").unwrap();
+    let mut ticket_buf = [0 as c_char; 65];
+    let rc = unsafe { cjt_turnstile_append(client, payload.as_ptr(), 0, ticket_buf.as_mut_ptr()) };
+    assert_eq!(rc, 0);
+    let ticket = unsafe { CStr::from_ptr(ticket_buf.as_ptr()) }.to_str().unwrap().to_string();
+
+    let ticket_c = CString::new(ticket.clone()).unwrap();
+    let rc = unsafe { cjt_confirm_ticket(client, ticket_c.as_ptr(), 1, std::ptr::null()) };
+    assert_eq!(rc, 0);
+
+    let mut latest_buf = [0 as c_char; 65];
+    let rc = unsafe { cjt_get_latest_leaf_hash(client, latest_buf.as_mut_ptr()) };
+    assert_eq!(rc, 0);
+    let latest = unsafe { CStr::from_ptr(latest_buf.as_ptr()) }.to_str().unwrap();
+    assert_eq!(latest, ticket);
+
+    unsafe { cjt_destroy(client) };
+}
+
+extern "C" fn fail_callback(_prev: *const c_char, _payload: *const c_char, _hash: *const c_char) -> c_int {
+    0
+}
+
+#[test]
+fn test_ffi_retry_flow() {
+    let cfg = CString::new("{\"max_retries\":1}").unwrap();
+    let client = unsafe { cjt_init(cfg.as_ptr()) };
+    assert!(!client.is_null());
+
+    let payload = CString::new("{\"x\":1}").unwrap();
+    let mut ticket_buf = [0 as c_char; 65];
+    let rc = unsafe { cjt_turnstile_append(client, payload.as_ptr(), 0, ticket_buf.as_mut_ptr()) };
+    assert_eq!(rc, 0);
+
+    let rc = unsafe { cjt_retry_next_pending(client, Some(fail_callback)) };
+    assert_eq!(rc, 2);
+
+    unsafe { cjt_destroy(client) };
+}
+
+#[test]
+fn test_ffi_orphan_logging_disabled() {
+    let cfg = CString::new("{\"orphan_event_logging\":false}").unwrap();
+    let client = unsafe { cjt_init(cfg.as_ptr()) };
+    assert!(!client.is_null());
+
+    let payload = CString::new("{\"x\":1}").unwrap();
+    let mut ticket_buf = [0 as c_char; 65];
+    let rc = unsafe { cjt_turnstile_append(client, payload.as_ptr(), 0, ticket_buf.as_mut_ptr()) };
+    assert_eq!(rc, 0);
+    let ticket = unsafe { CStr::from_ptr(ticket_buf.as_ptr()) }.to_str().unwrap().to_string();
+
+    let err = CString::new("fail").unwrap();
+    let t_c = CString::new(ticket.clone()).unwrap();
+    let rc = unsafe { cjt_confirm_ticket(client, t_c.as_ptr(), 0, err.as_ptr()) };
+    assert_eq!(rc, 0);
+
+    let mut latest_buf = [0 as c_char; 65];
+    unsafe { cjt_get_latest_leaf_hash(client, latest_buf.as_mut_ptr()) };
+    let latest = unsafe { CStr::from_ptr(latest_buf.as_ptr()) }.to_str().unwrap();
+    assert_eq!(latest, "0000000000000000000000000000000000000000000000000000000000000000");
+
+    unsafe { cjt_destroy(client) };
+}

--- a/tests/turnstile_tests.rs
+++ b/tests/turnstile_tests.rs
@@ -1,0 +1,73 @@
+use civicjournal_time::turnstile::Turnstile;
+use tempfile::tempdir;
+
+#[test]
+fn test_turnstile_append_confirm_flow() {
+    let mut ts = Turnstile::new("00".repeat(32), 3);
+    let ticket = ts.append("{\"foo\":\"bar\"}", 0).unwrap();
+    assert_eq!(
+        ticket,
+        "671fde0a1b5143bb2f28c9f08f5db13fed479b6313f56f8145260615d8cb05b4"
+    );
+    assert_eq!(ts.pending_count(), 1);
+    ts.confirm_ticket(&ticket, true, None).unwrap();
+    assert!(ts.leaf_exists(&ticket).unwrap());
+    assert_eq!(ts.pending_count(), 0);
+}
+
+#[test]
+fn test_turnstile_list_pending() {
+    let mut ts = Turnstile::new("00".repeat(32), 3);
+    let t1 = ts.append("{\"a\":1}", 1).unwrap();
+    let t2 = ts.append("{\"b\":2}", 2).unwrap();
+    let pending = ts.list_pending(10);
+    assert_eq!(pending.len(), 2);
+    assert!(pending.contains(&t1));
+    assert!(pending.contains(&t2));
+}
+
+#[test]
+fn test_turnstile_persistence() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ts");
+    let mut ts = Turnstile::new_with_storage("00".repeat(32), 3, Some(path.clone()), true);
+    let t1 = ts.append("{\"a\":1}", 1).unwrap();
+    drop(ts);
+    let ts2 = Turnstile::new_with_storage("ignored".to_string(), 3, Some(path), true);
+    assert!(ts2.leaf_exists(&t1).unwrap());
+    assert_eq!(ts2.pending_count(), 1);
+}
+
+#[test]
+fn test_turnstile_retry_logic() {
+    let mut ts = Turnstile::new("00".repeat(32), 1);
+    ts.append("{\"x\":1}", 1).unwrap();
+    let rc = ts
+        .retry_next_pending(|_, _, _| 0)
+        .expect("retry");
+    assert_eq!(rc, 2); // exceeded retries
+    assert_eq!(ts.pending_count(), 0);
+}
+
+#[test]
+fn test_orphan_event_logged() {
+    let mut ts = Turnstile::new("00".repeat(32), 3);
+    let t = ts.append("{\"z\":1}", 10).unwrap();
+    ts.confirm_ticket(&t, false, Some("db error")).unwrap();
+    assert_eq!(ts.orphan_events().len(), 1);
+    assert_eq!(ts.orphan_events()[0].orig_hash, t);
+    assert_eq!(ts.latest_leaf_hash(), ts.orphan_events()[0].leaf_hash);
+}
+
+#[test]
+fn test_orphan_logging_disabled() {
+    let mut ts = Turnstile::new_with_storage("00".repeat(32), 3, None, false);
+    let t = ts.append("{\"a\":1}", 0).unwrap();
+    ts.confirm_ticket(&t, false, Some("err")).unwrap();
+    assert_eq!(ts.orphan_events().len(), 0);
+    let prev = ts.latest_leaf_hash();
+    ts.append("{\"b\":2}", 1).unwrap();
+    ts.retry_next_pending(|_, _, _| 0).unwrap();
+    assert_eq!(ts.orphan_events().len(), 0);
+    assert_eq!(ts.latest_leaf_hash(), prev);
+}


### PR DESCRIPTION
## Summary
- persist turnstile state to disk
- implement FFI for all documented turnstile operations
- add tests for persistence and retry logic
- log orphan events and expose CJT client API
- add config option to disable orphan event logging
- add FFI integration tests for Turnstile
- implement orphan leaves in chain and adjust tests

## Testing
- `cargo test --test turnstile_tests -- --test-threads=1`
- `cargo test --test turnstile_ffi_tests -- --test-threads=1`
- `cargo test -- --test-threads=1` *(fails: 68 passed, 3 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841ebd35638832ca38cabfe71c98c74