### PR TITLE
Run tests and fix Cargo dependency issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ chrono-tz = { version = "0.8", optional = true }
 sha2 = "0.10"
 hex = "0.4"
 ring = { version = "0.17", optional = true }  # For cryptographic operations
-libc = "0.2"
 
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "sync", "time", "test-util"], optional = true }


### PR DESCRIPTION
## Summary
- fix duplicate `libc` dependency in Cargo.toml
- run the full test suite

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6842190b7564832c8ec74ff3580af35d