### PR TITLE
Expand MemoryStorage test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,17 @@ Ensure all components are functioning correctly:
 ```bash
 cargo test
 ```
+This runs all unit and integration tests, including the expanded memory
+storage suite located in `tests/memory_storage_tests.rs`. These tests now
+cover failure simulation, page and leaf lookups, existence checks and
+clearing logic, concurrency, targeted and level-wide failure simulation for
+the in-memory backend.
+Additional unit tests in `tests/basic_types_tests.rs` verify enum conversions
+for common types and constructors for core error helpers.
+Turnstile tests in `tests/turnstile_tests.rs` cover persistence, retry logic,
+orphan handling, and invalid input including corruption detection.
+Page behavior tests in `tests/page_behavior_tests.rs` validate net patch hashing
+order independence and the page finalization logic.
 
 For running tests that manipulate time for age-based rollup testing:
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -149,6 +149,8 @@ tests/
     └── corpus/        # Test corpora
 ```
 
+Recent test files in the root `tests/` directory include `file_storage_tests.rs`, `time_manager_tests.rs`, `basic_types_tests.rs`, and the expanded `memory_storage_tests.rs` which verifies in-memory backend behavior. The memory storage tests now exercise leaf lookup, page deletion, clearing logic, concurrency checks, targeted and level-wide failure simulation in addition to page summaries. The basic types suite checks conversions for common enums and error helper constructors. The `turnstile_tests.rs` file validates persistence and retry logic along with invalid JSON and bad hash handling. A `page_behavior_tests.rs` file covers canonical hashing of net patches and page finalization rules.
+
 ### Test Modules
 
 Each test module should follow this structure:

--- a/tests/basic_types_tests.rs
+++ b/tests/basic_types_tests.rs
@@ -1,0 +1,65 @@
+use civicjournal_time::types::{
+    CompressionAlgorithm,
+    StorageType,
+    LogLevel,
+    ConfigError,
+};
+use civicjournal_time::error::CJError;
+use std::str::FromStr;
+
+#[test]
+fn test_compression_display() {
+    assert_eq!(CompressionAlgorithm::default().to_string(), "zstd");
+    assert_eq!(CompressionAlgorithm::Lz4.to_string(), "lz4");
+    assert_eq!(CompressionAlgorithm::Snappy.to_string(), "snappy");
+    assert_eq!(CompressionAlgorithm::None.to_string(), "none");
+}
+
+#[test]
+fn test_storage_type_parse_and_display() {
+    assert_eq!(StorageType::from_str("memory").unwrap(), StorageType::Memory);
+    assert_eq!(StorageType::from_str("file").unwrap(), StorageType::File);
+    assert!(StorageType::from_str("other").is_err());
+    assert_eq!(StorageType::default().to_string(), "file");
+}
+
+#[test]
+fn test_log_level_display_and_parse() {
+    assert_eq!(LogLevel::Debug.to_string(), "debug");
+    assert_eq!("error".parse::<LogLevel>().unwrap(), LogLevel::Error);
+    assert!("bogus".parse::<LogLevel>().is_err());
+}
+
+#[test]
+fn test_config_error_invalid_value_helper() {
+    let err = ConfigError::invalid_value("f", 42, "nope");
+    match err {
+        ConfigError::InvalidValue { field, value, reason } => {
+            assert_eq!(field, "f");
+            assert_eq!(value, "42");
+            assert_eq!(reason, "nope");
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn test_cjerror_helper_constructors() {
+    let e = CJError::invalid_input("bad");
+    assert!(matches!(e, CJError::InvalidInput(ref s) if s == "bad"));
+
+    let e = CJError::not_found("x");
+    assert!(matches!(e, CJError::NotFound(ref s) if s == "x"));
+
+    let e = CJError::not_supported("y");
+    assert!(matches!(e, CJError::NotSupported(ref s) if s == "y"));
+
+    let e = CJError::timeout("z");
+    assert!(matches!(e, CJError::Timeout(ref s) if s == "z"));
+
+    let e = CJError::already_in_use("r");
+    assert!(matches!(e, CJError::AlreadyInUse(ref s) if s == "r"));
+
+    let e = CJError::not_initialized("n");
+    assert!(matches!(e, CJError::NotInitialized(ref s) if s == "n"));
+}

--- a/tests/memory_storage_tests.rs
+++ b/tests/memory_storage_tests.rs
@@ -1,0 +1,190 @@
+use civicjournal_time::storage::memory::MemoryStorage;
+use civicjournal_time::storage::StorageBackend;
+use civicjournal_time::core::page::JournalPage;
+use civicjournal_time::test_utils::{SHARED_TEST_ID_MUTEX, reset_global_ids, get_test_config};
+use chrono::Utc;
+
+use futures::future::join_all;
+#[tokio::test]
+async fn test_fail_on_store_and_clear() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let page = JournalPage::new(0, None, Utc::now(), cfg);
+
+    storage.set_fail_on_store(0, Some(page.page_id));
+    let res = storage.store_page(&page).await;
+    assert!(res.is_err(), "store_page should fail when fail_on_store is set");
+
+    storage.clear_fail_on_store();
+    storage.store_page(&page).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_list_finalized_pages_summary_sorted() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let now = Utc::now();
+
+    let mut first = JournalPage::new(0, None, now, cfg);
+    first.recalculate_merkle_root_and_page_hash();
+    let mut second = JournalPage::new(0, Some(first.page_hash), now, cfg);
+    second.recalculate_merkle_root_and_page_hash();
+
+    storage.store_page(&second).await.unwrap();
+    storage.store_page(&first).await.unwrap();
+
+    let summaries = storage.list_finalized_pages_summary(0).await.unwrap();
+    assert_eq!(summaries.len(), 2);
+    assert!(summaries[0].page_id < summaries[1].page_id);
+}
+
+#[tokio::test]
+async fn test_backup_and_restore_behavior() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let dir = tempfile::tempdir().unwrap();
+    let backup_path = dir.path().join("backup.zip");
+
+    storage.backup_journal(&backup_path).await.unwrap();
+    let res = storage.restore_journal(&backup_path, dir.path()).await;
+    assert!(res.is_err(), "restore_journal should return an error for MemoryStorage");
+}
+
+#[tokio::test]
+async fn test_load_page_by_hash() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let mut page = JournalPage::new(0, None, Utc::now(), cfg);
+    page.recalculate_merkle_root_and_page_hash();
+    storage.store_page(&page).await.unwrap();
+
+    let loaded = storage.load_page_by_hash(page.page_hash).await.unwrap();
+    assert!(loaded.is_some());
+    assert_eq!(loaded.unwrap().page_id, page.page_id);
+}
+
+#[tokio::test]
+async fn test_load_leaf_by_hash() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let mut page = JournalPage::new(0, None, Utc::now(), cfg);
+    let leaf = civicjournal_time::core::leaf::JournalLeaf::new(
+        Utc::now(),
+        None,
+        "c1".into(),
+        serde_json::json!({"foo": 1}),
+    )
+    .unwrap();
+    if let civicjournal_time::core::page::PageContent::Leaves(ref mut v) = page.content {
+        v.push(leaf.clone());
+    }
+    page.recalculate_merkle_root_and_page_hash();
+    storage.store_page(&page).await.unwrap();
+
+    let found = storage.load_leaf_by_hash(&leaf.leaf_hash).await.unwrap();
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().leaf_id, leaf.leaf_id);
+}
+
+#[tokio::test]
+async fn test_page_exists_and_delete() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let page = JournalPage::new(0, None, Utc::now(), cfg);
+
+    storage.store_page(&page).await.unwrap();
+    assert!(storage
+        .page_exists(page.level, page.page_id)
+        .await
+        .unwrap());
+
+    storage.delete_page(page.level, page.page_id).await.unwrap();
+    assert!(!storage
+        .page_exists(page.level, page.page_id)
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn test_is_empty_and_clear() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let page = JournalPage::new(0, None, Utc::now(), cfg);
+
+    assert!(storage.is_empty());
+    storage.store_page(&page).await.unwrap();
+    assert!(!storage.is_empty());
+    storage.clear();
+    assert!(storage.is_empty());
+}
+#[tokio::test]
+async fn test_fail_on_store_any_page() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let page = JournalPage::new(0, None, Utc::now(), cfg);
+
+    storage.set_fail_on_store(0, None);
+    assert!(storage.store_page(&page).await.is_err());
+
+    storage.clear_fail_on_store();
+    storage.store_page(&page).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fail_condition_non_matching_page() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let page1 = JournalPage::new(0, None, Utc::now(), cfg);
+    let page2 = JournalPage::new_with_id(page1.page_id + 1, 0, None, Utc::now(), cfg);
+
+    storage.set_fail_on_store(0, Some(page2.page_id));
+
+    // Should succeed because the fail condition targets a different page
+    storage.store_page(&page1).await.unwrap();
+
+    // Storing the targeted page should fail
+    assert!(storage.store_page(&page2).await.is_err());
+
+    storage.clear_fail_on_store();
+}
+#[tokio::test]
+async fn test_concurrent_store_and_load() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let storage = MemoryStorage::new();
+    let cfg = get_test_config();
+    let mut handles = Vec::new();
+
+    for i in 0..5u64 {
+        let storage_clone = storage.clone();
+        let cfg_ref = cfg;
+        handles.push(tokio::spawn(async move {
+            let page = JournalPage::new_with_id(i, 0, None, Utc::now(), cfg_ref);
+            storage_clone.store_page(&page).await.unwrap();
+            page.page_id
+        }));
+    }
+
+    let ids: Vec<u64> = join_all(handles).await.into_iter().map(|r| r.unwrap()).collect();
+
+    for id in ids {
+        assert!(storage.page_exists(0, id).await.unwrap());
+    }
+}

--- a/tests/page_behavior_tests.rs
+++ b/tests/page_behavior_tests.rs
@@ -1,0 +1,98 @@
+use civicjournal_time::core::page::{JournalPage, PageContent};
+use civicjournal_time::core::leaf::JournalLeaf;
+use civicjournal_time::config::{Config, TimeHierarchyConfig, TimeLevel, LevelRollupConfig};
+use civicjournal_time::types::time::RollupContentType;
+use civicjournal_time::test_utils::{SHARED_TEST_ID_MUTEX, reset_global_ids};
+use chrono::{Utc, Duration};
+use serde_json::json;
+use std::collections::HashMap;
+
+fn net_patch_config() -> Config {
+    Config {
+        time_hierarchy: TimeHierarchyConfig {
+            levels: vec![
+                TimeLevel {
+                    name: "L0".to_string(),
+                    duration_seconds: 60,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 10,
+                        max_page_age_seconds: 300,
+                        content_type: RollupContentType::ChildHashes,
+                    },
+                    retention_policy: None,
+                },
+                TimeLevel {
+                    name: "L1".to_string(),
+                    duration_seconds: 300,
+                    rollup_config: LevelRollupConfig {
+                        max_items_per_page: 10,
+                        max_page_age_seconds: 600,
+                        content_type: RollupContentType::NetPatches,
+                    },
+                    retention_policy: None,
+                },
+            ],
+        },
+        force_rollup_on_shutdown: false,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn test_net_patch_canonical_hashing() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let cfg = net_patch_config();
+    let now = Utc::now();
+
+    let mut page1 = JournalPage::new_with_id(0, 1, None, now, &cfg);
+    page1.content = PageContent::NetPatches(HashMap::new());
+    let mut p1_obj2 = HashMap::new();
+    p1_obj2.insert("b".to_string(), json!(2));
+    let mut p1_obj1 = HashMap::new();
+    p1_obj1.insert("a".to_string(), json!(1));
+    if let PageContent::NetPatches(ref mut map) = page1.content {
+        map.insert("obj2".to_string(), p1_obj2);
+        map.insert("obj1".to_string(), p1_obj1);
+    }
+    page1.recalculate_merkle_root_and_page_hash();
+
+    let mut page2 = JournalPage::new_with_id(0, 1, None, now, &cfg);
+    page2.content = PageContent::NetPatches(HashMap::new());
+    let mut p2_obj1 = HashMap::new();
+    p2_obj1.insert("a".to_string(), json!(1));
+    let mut p2_obj2 = HashMap::new();
+    p2_obj2.insert("b".to_string(), json!(2));
+    if let PageContent::NetPatches(ref mut map) = page2.content {
+        map.insert("obj1".to_string(), p2_obj1);
+        map.insert("obj2".to_string(), p2_obj2);
+    }
+    page2.recalculate_merkle_root_and_page_hash();
+
+    assert_eq!(page1.page_hash, page2.page_hash, "hashing should be order independent");
+}
+
+#[tokio::test]
+async fn test_should_finalize_conditions() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let cfg = net_patch_config();
+    let t0 = Utc::now();
+    let mut page = JournalPage::new(0, None, t0, &cfg);
+    let leaf = JournalLeaf::new(t0, None, "c".into(), json!({"a":1})).unwrap();
+    if let PageContent::Leaves(ref mut v) = page.content { v.push(leaf); }
+    page.recalculate_merkle_root_and_page_hash();
+
+    let res = page.should_finalize(t0 + Duration::seconds(10), t0 + Duration::seconds(10), 2, Some(Duration::seconds(300)));
+    assert_eq!(res, (false, false));
+
+    let res = page.should_finalize(t0 + Duration::seconds(10), t0 + Duration::seconds(10), 1, Some(Duration::seconds(300)));
+    assert_eq!(res, (true, false));
+
+    let res = page.should_finalize(t0 + Duration::seconds(10), t0 + Duration::seconds(301), 2, Some(Duration::seconds(300)));
+    assert_eq!(res, (true, false));
+
+    let res = page.should_finalize(page.end_time + Duration::seconds(1), page.end_time + Duration::seconds(1), 2, Some(Duration::seconds(300)));
+    assert_eq!(res, (false, true));
+}
+

--- a/tests/turnstile_tests.rs
+++ b/tests/turnstile_tests.rs
@@ -71,3 +71,14 @@ fn test_orphan_logging_disabled() {
     assert_eq!(ts.orphan_events().len(), 0);
     assert_eq!(ts.latest_leaf_hash(), prev);
 }
+
+#[test]
+fn test_append_invalid_json_and_prev_hash() {
+    // invalid JSON should produce an error
+    let mut ts = Turnstile::new("00".repeat(32), 3);
+    assert!(ts.append("{" , 0).is_err());
+
+    // invalid previous hash also results in error
+    let mut ts = Turnstile::new("zz".into(), 3);
+    assert!(ts.append("{\"a\":1}", 0).is_err());
+}


### PR DESCRIPTION
## Summary
- extend README and TESTS docs with targeted failure tests
- add integration test covering non-matching fail condition for MemoryStorage
- expand tests with basic types and error helpers
- add turnstile input validation tests and corruption detection check
- add page behavior tests covering net patch hashing and finalization

## Testing
- `cargo test`
- `cargo tarpaulin --out Html` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6842867e14bc832c8d35eb271881df09