### PR TITLE
Add hash utility tests

### DIFF
--- a/tests/hash_tests.rs
+++ b/tests/hash_tests.rs
@@ -1,0 +1,24 @@
+use civicjournal_time::core::hash::{sha256_hash, sha256_hash_concat};
+use hex;
+
+#[test]
+fn test_sha256_hash_empty() {
+    let expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    let actual = sha256_hash(b"");
+    assert_eq!(hex::encode(actual), expected);
+}
+
+#[test]
+fn test_sha256_hash_concat_multiple() {
+    let slices: &[&[u8]] = &[b"foo", b"bar", b"baz"];
+    let expected = "97df3588b5a3f24babc3851b372f0ba71a9dcdded43b14b9d06961bfc1707d9d";
+    let actual = sha256_hash_concat(slices);
+    assert_eq!(hex::encode(actual), expected);
+}
+
+#[test]
+fn test_sha256_hash_concat_empty() {
+    let expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    let actual = sha256_hash_concat(&[]);
+    assert_eq!(hex::encode(actual), expected);
+}


### PR DESCRIPTION
## Summary
- test `sha256_hash` on empty input
- ensure `sha256_hash_concat` works for multiple slices and empty slice

## Testing
- `cargo test --quiet --test hash_tests`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6843179859e8832c974b3aa426e93c9d