### PR TITLE
Add page integrity tests for corruption and missing pages

### DIFF
--- a/tests/query_engine_tests.rs
+++ b/tests/query_engine_tests.rs
@@ -1,7 +1,7 @@
 use civicjournal_time::query::QueryEngine;
 use civicjournal_time::storage::memory::MemoryStorage;
 use civicjournal_time::storage::StorageBackend;
-use civicjournal_time::core::page::JournalPage;
+use civicjournal_time::core::page::{JournalPage, JournalPageSummary};
 use civicjournal_time::core::leaf::JournalLeaf;
 use civicjournal_time::core::time_manager::TimeHierarchyManager;
 use civicjournal_time::config::Config;
@@ -9,6 +9,65 @@ use chrono::{Utc, Duration};
 use serde_json::json;
 use civicjournal_time::test_utils::{SHARED_TEST_ID_MUTEX, reset_global_ids};
 use std::sync::Arc;
+use civicjournal_time::error::CJError;
+use async_trait::async_trait;
+use std::path::Path;
+
+#[derive(Clone, Debug)]
+struct MemoryStorageWithExtraSummary {
+    inner: MemoryStorage,
+    summary: JournalPageSummary,
+}
+
+impl MemoryStorageWithExtraSummary {
+    fn new(inner: MemoryStorage, summary: JournalPageSummary) -> Self {
+        Self { inner, summary }
+    }
+}
+
+#[async_trait]
+impl StorageBackend for MemoryStorageWithExtraSummary {
+    async fn store_page(&self, page: &JournalPage) -> Result<(), CJError> {
+        self.inner.store_page(page).await
+    }
+
+    async fn load_page(&self, level: u8, page_id: u64) -> Result<Option<JournalPage>, CJError> {
+        self.inner.load_page(level, page_id).await
+    }
+
+    async fn page_exists(&self, level: u8, page_id: u64) -> Result<bool, CJError> {
+        self.inner.page_exists(level, page_id).await
+    }
+
+    async fn delete_page(&self, level: u8, page_id: u64) -> Result<(), CJError> {
+        self.inner.delete_page(level, page_id).await
+    }
+
+    async fn list_finalized_pages_summary(&self, level: u8) -> Result<Vec<JournalPageSummary>, CJError> {
+        let mut list = self.inner.list_finalized_pages_summary(level).await?;
+        if self.summary.level == level {
+            list.push(self.summary.clone());
+        }
+        list.sort_by_key(|s| s.page_id);
+        Ok(list)
+    }
+
+    async fn backup_journal(&self, backup_path: &Path) -> Result<(), CJError> {
+        self.inner.backup_journal(backup_path).await
+    }
+
+    async fn restore_journal(&self, backup_path: &Path, target_journal_dir: &Path) -> Result<(), CJError> {
+        self.inner.restore_journal(backup_path, target_journal_dir).await
+    }
+
+    async fn load_page_by_hash(&self, page_hash: [u8; 32]) -> Result<Option<JournalPage>, CJError> {
+        self.inner.load_page_by_hash(page_hash).await
+    }
+
+    async fn load_leaf_by_hash(&self, leaf_hash: &[u8; 32]) -> Result<Option<JournalLeaf>, CJError> {
+        self.inner.load_leaf_by_hash(leaf_hash).await
+    }
+}
 
 #[tokio::test]
 async fn test_reconstruct_and_delta_report() {
@@ -162,5 +221,68 @@ async fn test_page_chain_integrity_detects_mismatch() {
     assert_eq!(reports.len(), 2);
     assert!(reports[1].issues.iter().any(|i| i.contains("prev_page_hash")));
     assert!(!reports[1].is_valid);
+}
+
+#[tokio::test]
+async fn test_page_chain_integrity_detects_corrupted_page() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let config = Arc::new(Config::default());
+    let storage = Arc::new(MemoryStorage::new());
+    let tm = Arc::new(TimeHierarchyManager::new(config.clone(), storage.clone()));
+    let engine = QueryEngine::new(storage.clone(), tm, config.clone());
+
+    let t0 = Utc::now();
+    let mut page1 = JournalPage::new(0, None, t0, &config);
+    page1.recalculate_merkle_root_and_page_hash();
+    storage.store_page(&page1).await.unwrap();
+
+    let mut page2 = JournalPage::new(0, Some(page1.page_hash), t0 + Duration::seconds(1), &config);
+    page2.recalculate_merkle_root_and_page_hash();
+    if let civicjournal_time::core::page::PageContent::Leaves(ref mut v) = page2.content {
+        v.push(JournalLeaf::new(t0 + Duration::seconds(2), None, "c".into(), json!({"a":1})).unwrap());
+    }
+    // Intentionally do not recalculate hashes after modifying content
+    storage.store_page(&page2).await.unwrap();
+
+    let reports = engine
+        .get_page_chain_integrity(0, Some(page1.page_id), Some(page2.page_id))
+        .await
+        .unwrap();
+    assert_eq!(reports.len(), 2);
+    assert!(reports[0].is_valid);
+    assert!(!reports[1].is_valid);
+    assert!(reports[1].issues.iter().any(|i| i.contains("merkle_root")));
+    assert!(reports[1].issues.iter().any(|i| i.contains("page_hash")));
+}
+
+#[tokio::test]
+async fn test_page_chain_integrity_page_missing() {
+    let _guard = SHARED_TEST_ID_MUTEX.lock().await;
+    reset_global_ids();
+    let config = Arc::new(Config::default());
+    let base_storage = MemoryStorage::new();
+    let t0 = Utc::now();
+    let mut page1 = JournalPage::new(0, None, t0, &config);
+    page1.recalculate_merkle_root_and_page_hash();
+    base_storage.store_page(&page1).await.unwrap();
+
+    let missing_summary = JournalPageSummary {
+        page_id: 1,
+        level: 0,
+        creation_timestamp: t0 + Duration::seconds(1),
+        end_time: t0 + Duration::seconds(2),
+        page_hash: [0u8; 32],
+    };
+
+    let storage = Arc::new(MemoryStorageWithExtraSummary::new(base_storage, missing_summary));
+    let tm = Arc::new(TimeHierarchyManager::new(config.clone(), storage.clone()));
+    let engine = QueryEngine::new(storage.clone(), tm, config.clone());
+
+    let reports = engine.get_page_chain_integrity(0, None, None).await.unwrap();
+    assert_eq!(reports.len(), 2);
+    assert!(reports[0].is_valid);
+    assert!(!reports[1].is_valid);
+    assert!(reports[1].issues.iter().any(|i| i.contains("page missing")));
 }
 


### PR DESCRIPTION
## Summary
- extend `query_engine_tests` with a helper storage that can return extra page summaries
- test detection of corrupted page hashes and missing page files

## Testing
- `cargo test --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68431b908420832cb5bf0a54acdf2ed7