### PR TITLE
Implement paginated delta reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,10 @@ journal.restore("./backups/journal_backup.zip").await?;
 ### Querying Data
 
 ```rust
-// Get inclusion proof for a leaf
-let proof = journal.get_leaf_inclusion_proof(leaf_hash).await?;
+// Get inclusion proof for a leaf (optional page hint for efficiency)
+let proof = journal
+    .get_leaf_inclusion_proof_with_hint(leaf_hash, Some((0, 42)))
+    .await?;
 
 // Reconstruct container state at a specific time
 let state = journal.reconstruct_state(
@@ -345,6 +347,16 @@ let changes = journal.get_delta_report(
     Utc.ymd(2023, 1, 1).and_hms(0, 0, 0),
     Utc.ymd(2023, 1, 2).and_hms(0, 0, 0)
 ).await?;
+// or fetch results in pages
+let first_page = journal
+    .get_delta_report_paginated(
+        "container-123",
+        Utc.ymd(2023, 1, 1).and_hms(0, 0, 0),
+        Utc.ymd(2023, 1, 2).and_hms(0, 0, 0),
+        0,
+        100,
+    )
+    .await?;
 
 // Verify page chain integrity
 let is_valid = journal.verify_page_chain(0, Some(1), Some(100)).await?;

--- a/plan.md
+++ b/plan.md
@@ -39,14 +39,14 @@
      - [x] **`get_leaf_inclusion_proof(leaf_hash: [u8; 32])`**
        - [x] Complete implementation in `FileStorage` and `MemoryStorage`
        - [x] Add comprehensive tests for proof generation and verification
-       - [ ] Optimize with more efficient page searching and indexing
+       - [x] Optimize with more efficient page searching and indexing (page hint implemented)
      - [x] **`reconstruct_container_state(container_id: String, at_timestamp: DateTime<Utc>)`**
        - [x] Basic implementation for state reconstruction
        - [ ] Add performance optimizations for large datasets
        - [x] Add tests for various state reconstruction scenarios
      - [x] **`get_delta_report(container_id: String, from: DateTime<Utc>, to: DateTime<Utc>)`**
        - [x] Implement time-range based querying
-       - [ ] Add pagination support for large result sets
+       - [x] Add pagination support for large result sets
      - [x] **`get_page_chain_integrity(level: u8, from: Option<u64>, to: Option<u64>)`**
        - [x] Implement chain verification logic
        - [x] Add tests for chain verification

--- a/src/api/async_api.rs
+++ b/src/api/async_api.rs
@@ -118,6 +118,19 @@ impl Journal {
         self.query.get_leaf_inclusion_proof(leaf_hash).await.map_err(Into::into)
     }
 
+    /// Retrieves a leaf inclusion proof with an optional page hint to speed up lookups.
+    pub async fn get_leaf_inclusion_proof_with_hint(
+        &self,
+        leaf_hash: &[u8; 32],
+        page_id_hint: Option<(u8, u64)>,
+    ) -> CJResult<crate::query::types::LeafInclusionProof> {
+        self
+            .query
+            .get_leaf_inclusion_proof_with_hint(leaf_hash, page_id_hint)
+            .await
+            .map_err(Into::into)
+    }
+
     /// Reconstructs the state of a container at a timestamp.
     pub async fn reconstruct_container_state(&self, container_id: &str, at: DateTime<Utc>) -> CJResult<crate::query::types::ReconstructedState> {
         self.query.reconstruct_container_state(container_id, at).await.map_err(Into::into)
@@ -126,6 +139,22 @@ impl Journal {
     /// Gets a delta report for a container between two timestamps.
     pub async fn get_delta_report(&self, container_id: &str, from: DateTime<Utc>, to: DateTime<Utc>) -> CJResult<crate::query::types::DeltaReport> {
         self.query.get_delta_report(container_id, from, to).await.map_err(Into::into)
+    }
+
+    /// Gets a paginated delta report for a container between two timestamps.
+    pub async fn get_delta_report_paginated(
+        &self,
+        container_id: &str,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+        offset: usize,
+        limit: usize,
+    ) -> CJResult<crate::query::types::DeltaReport> {
+        self
+            .query
+            .get_delta_report_paginated(container_id, from, to, offset, limit)
+            .await
+            .map_err(Into::into)
     }
 
     /// Checks integrity of a range of pages.

--- a/src/api/sync_api.rs
+++ b/src/api/sync_api.rs
@@ -71,12 +71,37 @@ impl Journal {
         self.rt.block_on(self.query.get_leaf_inclusion_proof(leaf_hash)).map_err(Into::into)
     }
 
+    pub fn get_leaf_inclusion_proof_with_hint(
+        &self,
+        leaf_hash: &[u8; 32],
+        page_id_hint: Option<(u8, u64)>,
+    ) -> CJResult<crate::query::types::LeafInclusionProof> {
+        self
+            .rt
+            .block_on(self.query.get_leaf_inclusion_proof_with_hint(leaf_hash, page_id_hint))
+            .map_err(Into::into)
+    }
+
     pub fn reconstruct_container_state(&self, container_id: &str, at: DateTime<Utc>) -> CJResult<crate::query::types::ReconstructedState> {
         self.rt.block_on(self.query.reconstruct_container_state(container_id, at)).map_err(Into::into)
     }
 
     pub fn get_delta_report(&self, container_id: &str, from: DateTime<Utc>, to: DateTime<Utc>) -> CJResult<crate::query::types::DeltaReport> {
         self.rt.block_on(self.query.get_delta_report(container_id, from, to)).map_err(Into::into)
+    }
+
+    pub fn get_delta_report_paginated(
+        &self,
+        container_id: &str,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+        offset: usize,
+        limit: usize,
+    ) -> CJResult<crate::query::types::DeltaReport> {
+        self
+            .rt
+            .block_on(self.query.get_delta_report_paginated(container_id, from, to, offset, limit))
+            .map_err(Into::into)
     }
 
     pub fn get_page_chain_integrity(&self, level: u8, from: Option<u64>, to: Option<u64>) -> CJResult<Vec<crate::query::types::PageIntegrityReport>> {


### PR DESCRIPTION
## Summary
- add `get_delta_report_paginated` in `QueryEngine`
- expose paginated delta report via async and sync APIs
- document new method and example usage
- update development plan
- test pagination behavior in `query_engine_tests`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68438957f524832caffb266390f65b24