### PR TITLE
Add missing API docs and cleanup tests

### DIFF
--- a/src/api/sync_api.rs
+++ b/src/api/sync_api.rs
@@ -67,10 +67,18 @@ impl Journal {
         }
     }
 
+    /// Retrieves a leaf inclusion proof for the given leaf hash.
+    ///
+    /// This is a blocking wrapper around [`QueryEngine::get_leaf_inclusion_proof`]
+    /// for use in synchronous contexts.
     pub fn get_leaf_inclusion_proof(&self, leaf_hash: &[u8; 32]) -> CJResult<crate::query::types::LeafInclusionProof> {
         self.rt.block_on(self.query.get_leaf_inclusion_proof(leaf_hash)).map_err(Into::into)
     }
 
+    /// Retrieves a leaf inclusion proof with an optional page hint to speed up lookups.
+    ///
+    /// `page_id_hint` may contain the level and page ID where the caller believes
+    /// the leaf resides, avoiding a full search if correct.
     pub fn get_leaf_inclusion_proof_with_hint(
         &self,
         leaf_hash: &[u8; 32],
@@ -82,14 +90,20 @@ impl Journal {
             .map_err(Into::into)
     }
 
+    /// Reconstructs the state of a container at the specified timestamp.
     pub fn reconstruct_container_state(&self, container_id: &str, at: DateTime<Utc>) -> CJResult<crate::query::types::ReconstructedState> {
         self.rt.block_on(self.query.reconstruct_container_state(container_id, at)).map_err(Into::into)
     }
 
+    /// Retrieves all deltas for a container between two timestamps.
     pub fn get_delta_report(&self, container_id: &str, from: DateTime<Utc>, to: DateTime<Utc>) -> CJResult<crate::query::types::DeltaReport> {
         self.rt.block_on(self.query.get_delta_report(container_id, from, to)).map_err(Into::into)
     }
 
+    /// Retrieves a paginated delta report for a container between two timestamps.
+    ///
+    /// `offset` specifies how many matching deltas to skip before returning results
+    /// and `limit` caps the number of deltas returned.
     pub fn get_delta_report_paginated(
         &self,
         container_id: &str,
@@ -104,6 +118,10 @@ impl Journal {
             .map_err(Into::into)
     }
 
+    /// Verifies integrity of a range of pages at the given level.
+    ///
+    /// Returns a list of [`PageIntegrityReport`] entries describing any
+    /// inconsistencies.
     pub fn get_page_chain_integrity(&self, level: u8, from: Option<u64>, to: Option<u64>) -> CJResult<Vec<crate::query::types::PageIntegrityReport>> {
         self.rt.block_on(self.query.get_page_chain_integrity(level, from, to)).map_err(Into::into)
     }

--- a/src/core/page.rs
+++ b/src/core/page.rs
@@ -466,7 +466,6 @@ mod tests {
     use chrono::{Utc, Duration};
     use crate::core::leaf::{LeafData, LeafDataV1};
     use crate::core::merkle::MerkleTree;
-    use crate::storage::memory::MemoryStorage;
     use crate::storage::StorageBackend;
 
     // Removed local PAGE_TEST_MUTEX, lazy_static, and unused Mutex/Ordering imports

--- a/src/query/engine.rs
+++ b/src/query/engine.rs
@@ -224,6 +224,10 @@ pub async fn get_leaf_inclusion_proof_with_hint(
         }
     }
 
+    /// Rebuilds the state of a container at the specified timestamp.
+    ///
+    /// The returned [`ReconstructedState`] contains all deltas for the
+    /// container up to `at_timestamp` applied in order.
     pub async fn reconstruct_container_state(
         &self,
         container_id: &str,
@@ -264,6 +268,7 @@ pub async fn get_leaf_inclusion_proof_with_hint(
         Ok(ReconstructedState { container_id: container_id.to_string(), at_point: QueryPoint::Timestamp(at_timestamp), state_data: state })
     }
 
+    /// Retrieves all deltas for a container between two timestamps.
     pub async fn get_delta_report(
         &self,
         container_id: &str,
@@ -390,6 +395,9 @@ pub async fn get_leaf_inclusion_proof_with_hint(
         })
     }
 
+    /// Verifies the hash chain integrity for a range of pages at the given level.
+    ///
+    /// Returns a vector of [`PageIntegrityReport`] describing any detected issues.
     pub async fn get_page_chain_integrity(
         &self,
         level: u8,

--- a/tests/snapshot_manager_integration_tests.rs
+++ b/tests/snapshot_manager_integration_tests.rs
@@ -5,10 +5,8 @@ use civicjournal_time::{
     storage::memory::MemoryStorage,
     storage::StorageBackend,
     core::leaf::JournalLeaf,
-    core::page::{PageContent, JournalPage},
-    core::snapshot::{SnapshotContainerState, SnapshotPagePayload},
+    core::page::PageContent,
     core::merkle::MerkleTree, // For verifying empty Merkle root
-    error::CJError,
     types::time::{LevelRollupConfig, RollupContentType, TimeLevel}, // Added TimeLevel, RollupContentType is correct here
     StorageType, // Assuming StorageType is re-exported at crate::config or crate root
 };
@@ -243,7 +241,6 @@ async fn test_create_snapshot_with_finalized_l0_page() {
 
     let finalized_l0_pages = storage.list_finalized_pages_summary(0).await.unwrap();
     assert!(!finalized_l0_pages.is_empty(), "Expected at least one finalized L0 page");
-    let finalized_l0_page_summary = finalized_l0_pages.first().unwrap();
 
     let as_of_timestamp = now; 
     let result = snapshot_manager.create_snapshot(as_of_timestamp, None).await;

--- a/tests/time_manager_age_based_tests.rs
+++ b/tests/time_manager_age_based_tests.rs
@@ -5,13 +5,13 @@ use civicjournal_time::types::time::RollupContentType;
 use civicjournal_time::storage::memory::MemoryStorage;
 use civicjournal_time::config::{
     Config, TimeHierarchyConfig, TimeLevel, LevelRollupConfig, StorageConfig, LoggingConfig, MetricsConfig,
-    RetentionConfig, CompressionConfig
+    CompressionConfig
 };
 use civicjournal_time::StorageType;
 use civicjournal_time::LogLevel;
 use civicjournal_time::core::leaf::JournalLeaf;
 use std::sync::Arc;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use serde_json::json;
 use tokio::time::{sleep, Duration as TokioDuration};
 use civicjournal_time::test_utils::{SHARED_TEST_ID_MUTEX, reset_global_ids};

--- a/tests/turnstile_tests.rs
+++ b/tests/turnstile_tests.rs
@@ -204,7 +204,6 @@ fn test_append_invalid_json_and_prev_hash() {
 
 #[test]
 fn test_confirm_ticket_failure_marks_permanent_after_retries() {
-    use civicjournal_time::turnstile::PendingStatus;
     use serde_json::Value;
     use std::fs;
 


### PR DESCRIPTION
## Summary
- document Sync API methods
- document QueryEngine methods
- clean up unused imports in tests
- remove unused variable in snapshot integration tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684512579764832c9b2c74508e1fc749