### PR TITLE
Add automatic Postgres startup for demo mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ tokio-postgres = { version = "0.7", optional = true, features = ["with-serde_jso
 clap = { version = "4.4", features = ["derive"], optional = true }
 rand = { version = "0.8", optional = true }
 fake = { version = "2.7", features = ["derive", "chrono"], optional = true }
+pg-embed = { version = "0.7.1", optional = true, default-features = false, features = ["rt_tokio_migrate"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4"
 
@@ -107,7 +108,7 @@ crypto = ["ring"]
 concurrent = ["parking_lot"]
 
 # Demo mode utilities and PostgreSQL driver
-demo = ["async", "async_api", "logging", "dep:tokio-postgres", "dep:clap", "dep:fake", "dep:rand"]
+demo = ["async", "async_api", "logging", "dep:tokio-postgres", "dep:clap", "dep:fake", "dep:rand", "dep:pg-embed"]
 
 [[bin]]
 name = "journal-demo"

--- a/DEMOMODE.md
+++ b/DEMOMODE.md
@@ -131,8 +131,7 @@ PostgreSQL table. This allows the turnstile trigger in
 [`TURNSTILE.md`](TURNSTILE.md) to validate that the ledger and the database stay
 in sync.
 
-* Launch a dedicated Postgres instance (e.g. `journal_demo`). The simplest
-  option is a small Docker Compose file:
+* Launch a dedicated Postgres instance (e.g. `journal_demo`). If `database_url` is omitted the demo will automatically start PostgreSQL using Docker or an embedded server. To run manually use a small Docker Compose file:
 
   ```yaml
   services:

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Use the optional `demo` feature to generate sample data and explore rollups and 
 cargo run --features demo --bin journal-demo -- run --mode batch
 ```
 
-See [DEMOMODE.md](DEMOMODE.md) for full configuration and PostgreSQL setup instructions.
+If no database URL is provided, the demo automatically launches a local PostgreSQL instance using Docker or an embedded server. See [DEMOMODE.md](DEMOMODE.md) for full configuration and PostgreSQL setup instructions.
 
 ## WebAssembly Bindings
 

--- a/src/bin/journal-demo.rs
+++ b/src/bin/journal-demo.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "demo")]
 use clap::{Parser, Subcommand, ValueEnum};
-use civicjournal_time::demo::{DemoConfig, simulator::Simulator, explorer};
+use civicjournal_time::demo::{DemoConfig, simulator::Simulator, explorer, auto_db};
 use chrono::{DateTime, Utc};
 use civicjournal_time::api::async_api::Journal;
 use civicjournal_time::init;
@@ -44,13 +44,21 @@ enum Mode {
 async fn main() -> CJResult<()> {
     let cli = Cli::parse();
     let config = init(Some(&cli.config))?;
-    let demo_cfg = DemoConfig::load(&cli.config)?;
+    let mut demo_cfg = DemoConfig::load(&cli.config)?;
     match cli.command {
         Commands::Run { mode, wipe } => {
+            let mut _db_handle: Option<auto_db::PgHandle> = None;
+            if demo_cfg.database_url.is_none() {
+                if let Ok((url, handle)) = auto_db::launch_postgres().await {
+                    demo_cfg.database_url = Some(url);
+                    _db_handle = Some(handle);
+                }
+            }
             let journal = Journal::new(config).await?;
             let live = matches!(mode, Mode::Live);
             let mut sim = Simulator::new(demo_cfg, journal, wipe, live).await?;
             sim.run().await?;
+            drop(_db_handle);
         }
         Commands::Explore { container, at } => {
             let journal = Journal::new(config).await?;

--- a/src/demo/auto_db.rs
+++ b/src/demo/auto_db.rs
@@ -1,0 +1,76 @@
+#![cfg(feature = "demo")]
+use crate::CJResult;
+use std::process::Command;
+use std::time::Duration;
+use tokio::time::sleep;
+use tokio_postgres::NoTls;
+use std::path::PathBuf;
+use pg_embed::pg_fetch::{PgFetchSettings, PG_V15};
+use pg_embed::pg_enums::PgAuthMethod;
+use pg_embed::postgres::{PgEmbed, PgSettings};
+
+pub enum PgHandle {
+    Docker(String),
+    Embedded(PgEmbed),
+}
+
+impl Drop for PgHandle {
+    fn drop(&mut self) {
+        if let PgHandle::Docker(id) = self {
+            let _ = Command::new("docker").args(["rm", "-f", id]).output();
+        }
+    }
+}
+
+pub async fn launch_postgres() -> CJResult<(String, PgHandle)> {
+    if Command::new("docker").arg("--version").output().is_ok() {
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "-d",
+                "-e",
+                "POSTGRES_DB=journal_demo",
+                "-e",
+                "POSTGRES_USER=demo",
+                "-e",
+                "POSTGRES_PASSWORD=demo",
+                "-p",
+                "5432:5432",
+                "postgres:15",
+            ])
+            .output();
+        if let Ok(out) = output {
+            if out.status.success() {
+                let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                let url = "postgres://demo:demo@localhost:5432/journal_demo";
+                for _ in 0..10 {
+                    if tokio_postgres::connect(url, NoTls).await.is_ok() {
+                        return Ok((url.to_string(), PgHandle::Docker(id)));
+                    }
+                    sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+    let settings = PgSettings {
+        database_dir: PathBuf::from("target/pg_demo"),
+        port: 5432,
+        user: "demo".to_string(),
+        password: "demo".to_string(),
+        auth_method: PgAuthMethod::Plain,
+        persistent: false,
+        timeout: Some(Duration::from_secs(15)),
+        migration_dir: None,
+    };
+    let fetch = PgFetchSettings { version: PG_V15, ..Default::default() };
+    let mut pg = PgEmbed::new(settings, fetch)
+        .await
+        .map_err(|e| crate::CJError::new(e.to_string()))?;
+    pg.setup().await.map_err(|e| crate::CJError::new(e.to_string()))?;
+    pg.start_db().await.map_err(|e| crate::CJError::new(e.to_string()))?;
+    pg.create_database("journal_demo")
+        .await
+        .map_err(|e| crate::CJError::new(e.to_string()))?;
+    let url = pg.full_db_uri("journal_demo");
+    Ok((url, PgHandle::Embedded(pg)))
+}

--- a/src/demo/mod.rs
+++ b/src/demo/mod.rs
@@ -19,6 +19,8 @@ pub mod snapshot;
 pub mod explorer;
 #[cfg(feature = "demo")]
 pub mod postgres;
+#[cfg(feature = "demo")]
+pub mod auto_db;
 
 #[cfg(feature = "demo")]
 pub use config::DemoConfig;


### PR DESCRIPTION
## Summary
- add `pg-embed` dependency and use it in new `auto_db` helper
- launch Postgres automatically from `journal-demo` CLI when no URL configured
- document new behaviour in README and DEMOMODE

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684615e84df8832cb258781f82f10471