### PR TITLE
Improve embedded Postgres handling for demo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ fake = { version = "2.7", features = ["derive", "chrono"], optional = true }
 pg-embed = { version = "0.7.1", optional = true, default-features = false, features = ["rt_tokio_migrate"] }
 crossterm = { version = "0.27", optional = true }
 tui = { version = "0.19", default-features = false, features = ["crossterm"], optional = true }
+users = { version = "0.11", optional = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4"
 
@@ -111,7 +112,7 @@ crypto = ["ring"]
 concurrent = ["parking_lot"]
 
 # Demo mode utilities and PostgreSQL driver
-demo = ["async", "async_api", "logging", "dep:tokio-postgres", "dep:clap", "dep:fake", "dep:rand", "dep:pg-embed", "dep:crossterm", "dep:tui"]
+demo = ["async", "async_api", "logging", "dep:tokio-postgres", "dep:clap", "dep:fake", "dep:rand", "dep:pg-embed", "dep:crossterm", "dep:tui", "dep:users"]
 
 [[bin]]
 name = "cj-demo"


### PR DESCRIPTION
## Summary
- guard embedded postgres start to prevent root execution
- fallback to explicit Postgres 15.7 package
- add users crate for UID check

## Testing
- `cargo run --features demo --bin cj-demo` (fails early with informative error)
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6847ca56539c832c8dc255fb3d5bc1af