### PR TITLE
Fix demo leaf chaining and use net patches

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,7 +19,12 @@ mod validation_tests;
 mod config_mod_tests;
 
 // Publicly re-export key configuration types from the types module
-pub use crate::types::time::{LevelRollupConfig, TimeHierarchyConfig, TimeLevel};
+pub use crate::types::time::{
+    LevelRollupConfig,
+    TimeHierarchyConfig,
+    TimeLevel,
+    RollupContentType,
+};
 
 use directories::ProjectDirs;
 use std::{
@@ -299,7 +304,10 @@ impl Default for Config {
                     TimeLevel {
                         name: "hour".to_string(),
                         duration_seconds: 3600,
-                        rollup_config: LevelRollupConfig::default(),
+                        rollup_config: LevelRollupConfig {
+                            content_type: RollupContentType::NetPatches,
+                            ..LevelRollupConfig::default()
+                        },
                         retention_policy: None,
                     },
                     TimeLevel {


### PR DESCRIPTION
## Summary
- enable RollupContentType::NetPatches for hour level
- chain leaves in demo `simulate` and `generate_demo_data`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6848655d2868832c9794bb632d98471c