### PR TITLE
Add dual rollup content combining child hashes with net patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,12 +307,12 @@ levels = [
 [[rollup.levels]]
 max_items_per_page = 1000
 max_page_age_seconds = 0     # age-based rollup disabled
-content_type = "ChildHashes"  # or "NetPatches"
+content_type = "ChildHashesAndNetPatches"  # stores hashes and a net patch summary
 
 [[rollup.levels]]
 max_items_per_page = 500
 max_page_age_seconds = 86400  # 1 day
-content_type = "ChildHashes"
+content_type = "ChildHashesAndNetPatches"
 
 [storage]
 type = "file"  # or "memory"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -299,7 +299,7 @@ impl Default for Config {
                         name: "minute".to_string(),
                         duration_seconds: 60,
                         rollup_config: LevelRollupConfig {
-                            content_type: RollupContentType::NetPatches,
+                            content_type: RollupContentType::ChildHashesAndNetPatches,
                             ..LevelRollupConfig::default()
                         },
                         retention_policy: None,
@@ -308,7 +308,7 @@ impl Default for Config {
                         name: "hour".to_string(),
                         duration_seconds: 3600,
                         rollup_config: LevelRollupConfig {
-                            content_type: RollupContentType::NetPatches,
+                            content_type: RollupContentType::ChildHashesAndNetPatches,
                             ..LevelRollupConfig::default()
                         },
                         retention_policy: None,

--- a/src/query/engine.rs
+++ b/src/query/engine.rs
@@ -174,6 +174,10 @@ pub async fn get_leaf_inclusion_proof_with_hint(
                             // snapshot_payload.container_states_merkle_root or other hashes from its header,
                             // but that's not relevant to proving a *JournalLeaf* that isn't part of this snapshot's direct content type.
                         }
+                        crate::core::page::PageContent::ThrallHashesWithNetPatches { hashes, .. } => {
+                            // Page stores both hashes and patches but no raw leaves.
+                            leaf_hashes_in_page.extend(hashes.iter().cloned());
+                        }
                     }
 
                     if found_leaf_in_page_contents {

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -871,6 +871,17 @@ mod tests {
                 patch_map.insert("obj1".to_string(), patch);
                 page1_1.merge_net_patches(patch_map, leaf_data_4.timestamp);
             }
+            RollupContentType::ChildHashesAndNetPatches => {
+                page1_1.add_thrall_hash(page0_1.page_hash, page0_1.end_time);
+                let mut patch = std::collections::HashMap::new();
+                patch.insert(
+                    "dummy_field".to_string(),
+                    serde_json::Value::String("dummy".to_string()),
+                );
+                let mut patch_map = std::collections::HashMap::new();
+                patch_map.insert("obj1".to_string(), patch);
+                page1_1.merge_net_patches(patch_map, leaf_data_4.timestamp);
+            }
         }
         page1_1.recalculate_merkle_root_and_page_hash();
         storage.store_page(&page1_1).await.expect("Failed to store page1_1");

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -344,10 +344,10 @@ mod tests {
         // Create L1 page (should not be searched for leaves)
         let mut page1_l1 = JournalPage::new(1, None, now, &config);
         // JournalPage::new for L1 creates PageContent::ThrallHashes. Add a hash to it.
-        if let PageContent::ThrallHashes(ref mut hashes) = page1_l1.content {
-            hashes.push([8u8; 32]);
-        } else {
-            panic!("L1 page content is not ThrallHashes as expected");
+        match &mut page1_l1.content {
+            PageContent::ThrallHashes(hashes) => hashes.push([8u8; 32]),
+            PageContent::ThrallHashesWithNetPatches { hashes, .. } => hashes.push([8u8; 32]),
+            _ => panic!("L1 page content type unexpected"),
         }
         page1_l1.recalculate_merkle_root_and_page_hash();
         storage.store_page(&page1_l1).await.unwrap();

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -44,11 +44,16 @@ pub enum RollupContentType {
     /// - You frequently query the latest state of objects
     /// - Storage efficiency is less critical than read performance
     NetPatches,
+
+    /// Represents rolled-up content that stores both the hashes of child pages
+    /// and a net patch summary. This provides cryptographic audit capability
+    /// while enabling swift state reconstruction.
+    ChildHashesAndNetPatches,
 }
 
 impl Default for RollupContentType {
     fn default() -> Self {
-        RollupContentType::ChildHashes // Default to existing behavior
+        RollupContentType::ChildHashesAndNetPatches
     }
 }
 

--- a/tests/memory_storage_unit_tests.rs
+++ b/tests/memory_storage_unit_tests.rs
@@ -102,7 +102,11 @@ async fn test_list_finalized_pages_summary() {
     let page1 = JournalPage::new(0, None, now, &cfg);
     let page2 = JournalPage::new(0, None, now + chrono::Duration::seconds(1), &cfg);
     let mut page3 = JournalPage::new(1, None, now, &cfg);
-    if let PageContent::ThrallHashes(ref mut v) = page3.content { v.push([1u8;32]); }
+    match &mut page3.content {
+        PageContent::ThrallHashes(v) => v.push([1u8;32]),
+        PageContent::ThrallHashesWithNetPatches { hashes, .. } => hashes.push([1u8;32]),
+        _ => panic!("L1 page content unexpected"),
+    }
     page3.recalculate_merkle_root_and_page_hash();
     storage.store_page(&page1).await.unwrap();
     storage.store_page(&page2).await.unwrap();
@@ -159,7 +163,11 @@ async fn test_load_leaf_by_hash_behavior() {
     l0.recalculate_merkle_root_and_page_hash();
     storage.store_page(&l0).await.unwrap();
     let mut l1 = JournalPage::new(1, None, now, &cfg);
-    if let PageContent::ThrallHashes(ref mut v) = l1.content { v.push([9u8;32]); }
+    match &mut l1.content {
+        PageContent::ThrallHashes(v) => v.push([9u8;32]),
+        PageContent::ThrallHashesWithNetPatches { hashes, .. } => hashes.push([9u8;32]),
+        _ => panic!("Expected thrall content"),
+    }
     l1.recalculate_merkle_root_and_page_hash();
     storage.store_page(&l1).await.unwrap();
     for lf in [&leaf1, &leaf2] {


### PR DESCRIPTION
## Summary
- introduce `ChildHashesAndNetPatches` rollup type and corresponding page variant
- update page creation, merging logic, and query engine to handle combined data
- adjust default configuration and documentation examples
- update memory storage tests to support new content type

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6848d66deb2c832cada7d3f10ead7862