### PR TITLE
Add progress bar and optimize demo generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ fake = { version = "2.7", features = ["derive", "chrono"], optional = true }
 pg-embed = { version = "0.7.1", optional = true, default-features = false, features = ["rt_tokio_migrate"] }
 crossterm = { version = "0.27", optional = true }
 tui = { version = "0.19", default-features = false, features = ["crossterm"], optional = true }
+indicatif = { version = "0.17", optional = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4"
 
@@ -111,7 +112,7 @@ crypto = ["ring"]
 concurrent = ["parking_lot"]
 
 # Demo mode utilities and PostgreSQL driver
-demo = ["async", "async_api", "logging", "dep:tokio-postgres", "dep:clap", "dep:fake", "dep:rand", "dep:pg-embed", "dep:crossterm", "dep:tui"]
+demo = ["async", "async_api", "logging", "dep:tokio-postgres", "dep:clap", "dep:fake", "dep:rand", "dep:pg-embed", "dep:crossterm", "dep:tui", "dep:indicatif"]
 
 [[bin]]
 name = "cj-demo"

--- a/src/api/async_api.rs
+++ b/src/api/async_api.rs
@@ -27,7 +27,7 @@ pub struct Journal {
     /// Query engine used by the journal.
     pub query: crate::query::QueryEngine,
     /// Tracks the hash of the most recently appended leaf.
-    last_leaf_hash: Arc<Mutex<Option<[u8; 32]>>>,
+    pub last_leaf_hash: Arc<Mutex<Option<[u8; 32]>>>,
 }
 
 impl Journal {
@@ -505,6 +505,7 @@ mod tests {
         let journal = Journal {
             manager: manager_arc,
             query,
+            last_leaf_hash: Arc::new(Mutex::new(None)),
         };
 
         let timestamp = Utc::now();

--- a/src/api/sync_api.rs
+++ b/src/api/sync_api.rs
@@ -15,7 +15,7 @@ pub struct Journal {
     manager: Arc<TimeHierarchyManager>,
     query: crate::query::QueryEngine,
     rt: Runtime, // Tokio runtime for executing async operations
-    last_leaf_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
+    pub last_leaf_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
 }
 
 impl Journal {

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -152,7 +152,7 @@ impl FileStorage {
     /// Constructs the path for a specific journal page file.
     /// Path: `base_path/journal/level_<L>/page_<ID>.cjt[.compression_alg]`
     fn get_page_path(&self, level: u8, page_id: u64) -> PathBuf {
-        let filename = format!("page_{}.cjt", page_id);
+        let filename = format!("page_{:08}.cjt", page_id);
         self.base_path
             .join(JOURNAL_SUBDIR)
             .join(format!("level_{}", level))


### PR DESCRIPTION
## Summary
- expose `last_leaf_hash` so tests can construct journals
- speed up demo data generation and show a progress bar
- zero-pad page filenames for better ordering
- update tests for new page naming
- cluster demo updates during daytime hours for 20y span

## Testing
- `cargo fmt --all -- --check`
- `cargo check --features demo`


------
https://chatgpt.com/codex/tasks/task_e_684b3c0a8148832ca5bb72e3c4ca8e8a