### PR TITLE
Fix default rollup config mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ let mut journal = Journal::new(cfg)?;
 journal.append_leaf("example", serde_json::json!({"msg": "hello"}))?;
 ```
 
+The built-in default uses a four-level hierarchy (`day` → `week` → `month` → `year`).
+Both the week and month levels store child hashes **and** net patch summaries so
+that the year level (which stores only net patches) can roll up without errors.
+
+
 
 ## Project Structure
 

--- a/ROLLUP.md
+++ b/ROLLUP.md
@@ -79,6 +79,12 @@ max_page_age_seconds = 0       # Age-based rollup disabled (finalize on activity
 content_type = "ChildHashesAndNetPatches"   # store hashes and optional net patch
 ```
 
+When a parent level is configured with `NetPatches`, its child level must also
+produce patch information (`ChildHashesAndNetPatches` or `NetPatches`).
+Otherwise the rollup will fail. The built-in default sets both the week and
+month levels to `ChildHashesAndNetPatches` so the year level (which stores only
+`NetPatches`) can aggregate data without errors.
+
 ### Retention Policies
 
 Retention policies control how long data is kept at each level:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -304,7 +304,7 @@ impl Default for Config {
                         name: "week".to_string(),
                         duration_seconds: 604_800,
                         rollup_config: LevelRollupConfig {
-                            content_type: RollupContentType::ChildHashes,
+                            content_type: RollupContentType::ChildHashesAndNetPatches,
                             ..LevelRollupConfig::default()
                         },
                         retention_policy: None,
@@ -313,7 +313,7 @@ impl Default for Config {
                         name: "month".to_string(),
                         duration_seconds: 2_592_000, // 30 days
                         rollup_config: LevelRollupConfig {
-                            content_type: RollupContentType::ChildHashes,
+                            content_type: RollupContentType::ChildHashesAndNetPatches,
                             ..LevelRollupConfig::default()
                         },
                         retention_policy: None,


### PR DESCRIPTION
## Summary
- fix week/month default rollup config so year level can roll up net patches
- document default hierarchy in README
- clarify rollup configuration requirements in ROLLUP.md

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684b5d8a4db4832cb9031f57761d38d7